### PR TITLE
Resolve Cannot read property 'forEach' of undefined for entry.messaging

### DIFF
--- a/lib/Botly.js
+++ b/lib/Botly.js
@@ -512,7 +512,8 @@ Botly.prototype.handleMessage = function (req) {
 
     this.emit('complete_message', body);
     body.entry.forEach(entry => {
-        entry.messaging.forEach(message => {
+        if (entry.messaging && entry.messaging.length) {
+          entry.messaging.forEach(message => {
             _handleOptIn.call(this, message);
             _handleDelivery.call(this, message);
             _handleRead.call(this, message);
@@ -521,7 +522,8 @@ Botly.prototype.handleMessage = function (req) {
             _handleAccountLinking.call(this, message);
             _handleUserMessage.call(this, message);
             _handleEcho.call(this, message);
-        }, this);
+          }, this);
+        }
     }, this);
 };
 


### PR DESCRIPTION
Added check if entry in handleMessage() has messaging child and it's length to prevent errors like "Cannot read property 'forEach' of undefined" when messaging is not defined