### PR TITLE
Added Thread Control to handle when bot is taking back control

### DIFF
--- a/lib/Botly.js
+++ b/lib/Botly.js
@@ -564,6 +564,7 @@ Botly.prototype.handleMessage = function (req) {
             _handleAccountLinking.call(this, message);
             _handleUserMessage.call(this, message);
             _handleEcho.call(this, message);
+            _handleThreadControl.call(this, message);
           }, this);
         }
     }, this);
@@ -637,6 +638,12 @@ function _handleUserMessage(message) {
 function _handleEcho(message) {
     if (message.message && message.message.is_echo) {
         this.emit('echo', message.sender.id, message, message.message, message.recipient.id);
+    }
+}
+
+function _handleThreadControl(message) {
+    if (message.pass_thread_control) {
+        this.emit('passThreadControl', message.sender.id, message, message.pass_thread_control, message.recipient.id);
     }
 }
 


### PR DESCRIPTION
when Transfer protocol is deactivate primary app (bot) is taking back control and a webhook is sent, this allow to manage the action when the bot is supposed to take back the thread