### PR TITLE
getUserProfile() support for specifying profile fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
     - [setWhitelist (options[, callback])](#setwhitelist-options-callback)
     - [setPersistentMenu (options[, callback])](#setpersistentmenue-options-callback)
     - [removePersistentMenu (options[, callback])](#removepersistentmenue-options-callback)]
-    - [getUserProfile (userId[, callback])](#getuserprofile-userid-callback)
+    - [getUserProfile (options[, callback])](#getuserprofile-options-callback)
     - [getPSID (accountLinkingToken[, callback])](#getpsid-accountlinkingtoken-callback)
     - [createWebURLButton (title, url[, heightRatio][, supportExtension][, fallbackURL][, disableShare])](#createweburlbutton-title-url-heightratio-supportextension-fallbackurl-disableshare)
     - [createAccountLinkButton (url)](#createaccountlinkbutton-url)
@@ -357,8 +357,26 @@ botly.removePersistentMenu(
     });
 ```
 
-#### getUserProfile (userId[, callback])
-Also supports passing an object as `{id: userId, accessToken: OTHER_TOKEN}`
+#### getUserProfile (options[, callback])
+Used to retrieve basic profile details by user page-scoped ID (PSID). You can pass the `userID` directly, in which case a default set of fields (`first_name`, `last_name`, `profile_pic`) are requested.
+
+Also supports passing an object as
+```javascript
+const options = {
+    id: userId,
+    fields: [
+        Botly.CONST.USER_PROFILE_FIELD.FIRST_NAME,
+        Botly.CONST.USER_PROFILE_FIELD.LAST_NAME
+    ],
+    accessToken: OTHER_TOKEN
+}
+
+botly.getUserProfile(options, function (err, info) {
+    //cache it
+});
+```
+
+or
 
 ```javascript
 botly.getUserProfile(userId, function (err, info) {

--- a/lib/Botly.js
+++ b/lib/Botly.js
@@ -64,6 +64,17 @@ const IMAGE_ASPECT_RATIO = {
     SQUARE: 'square'
 };
 
+const USER_PROFILE_FIELD = {
+    ID: 'id',
+    NAME: 'name',
+    FIRST_NAME: 'first_name',
+    LAST_NAME: 'last_name',
+    PROFILE_PIC: 'profile_pic',
+    LOCALE: 'locale',
+    TIMEZONE: 'timezone',
+    GENDER: 'gender'
+};
+
 function Botly(options) {
     if (!(this instanceof Botly)) {
         return new Botly(options);
@@ -147,8 +158,16 @@ Botly.prototype.getPSID = function (options, callback) {
 
 Botly.prototype.getUserProfile = function (options, callback) {
     let userId = options;
+    let fields = [
+        USER_PROFILE_FIELD.FIRST_NAME,
+        USER_PROFILE_FIELD.LAST_NAME,
+        USER_PROFILE_FIELD.PROFILE_PIC
+    ];
     if (typeof options === 'object') {
         userId = options.id;
+    }
+    if (Array.isArray(options.fields) && options.fields.length > 0) {
+        fields = options.fields;
     }
     const USER_URL = `${this.FB_URL}${userId}`;
 
@@ -156,7 +175,7 @@ Botly.prototype.getUserProfile = function (options, callback) {
         {
             url: USER_URL,
             qs: {
-                fields: 'first_name,last_name,profile_pic,locale,timezone,gender',
+                fields: fields.join(','),
                 access_token: this.accessToken || options.accessToken
             },
             json: true
@@ -660,7 +679,8 @@ Botly.CONST = {
     CONTENT_TYPE: CONTENT_TYPE,
     WEBVIEW_HEIGHT_RATIO: WEBVIEW_HEIGHT_RATIO,
     TOP_ELEMENT_STYLE: TOP_ELEMENT_STYLE,
-    IMAGE_ASPECT_RATIO: IMAGE_ASPECT_RATIO
+    IMAGE_ASPECT_RATIO: IMAGE_ASPECT_RATIO,
+    USER_PROFILE_FIELD: USER_PROFILE_FIELD
 };
 
 module.exports = Botly;

--- a/test/botly_test.js
+++ b/test/botly_test.js
@@ -1129,7 +1129,7 @@ describe('Botly Tests', function () {
 
     });
 
-    it('should get user profile', done => {
+    it('should get user profile with default fields', done => {
         request.get.yields(
             {
                 first_name: 'miki'
@@ -1147,12 +1147,21 @@ describe('Botly Tests', function () {
             expect(data).to.eql({
                 first_name: 'miki'
             });
+
+            const expectedFields = [
+                Botly.CONST.USER_PROFILE_FIELD.FIRST_NAME,
+                Botly.CONST.USER_PROFILE_FIELD.LAST_NAME,
+                Botly.CONST.USER_PROFILE_FIELD.PROFILE_PIC
+            ].join(',');
+            const actualFields = request.get.getCall(0).args[0].qs.fields;
+            expect(expectedFields).to.equal(actualFields);
+
             done();
         });
 
     });
 
-    it('should get user profile with object ', done => {
+    it('should get user profile with object and specified fields', done => {
         request.get.yields(
             {
                 first_name: 'miki'
@@ -1165,11 +1174,22 @@ describe('Botly Tests', function () {
             notificationType: Botly.CONST.NOTIFICATION_TYPE.NO_PUSH
         });
 
-        botly.getUserProfile({id: USER_ID}, (data) => {
+        const options = {
+            id: USER_ID,
+            fields: [
+                Botly.CONST.USER_PROFILE_FIELD.FIRST_NAME,
+                Botly.CONST.USER_PROFILE_FIELD.PROFILE_PIC
+            ]
+        };
+        botly.getUserProfile(options, (data) => {
             expect(request.get.calledOnce).to.be.true;
             expect(data).to.eql({
                 first_name: 'miki'
             });
+
+            const expectedFields = options.fields.join(',');
+            const actualFields = request.get.getCall(0).args[0].qs.fields;
+            expect(actualFields).to.equal(expectedFields);
             done();
         });
 


### PR DESCRIPTION
This PR proposes a fix for Issue #52 _(Handle FB User Profile API changes to default profile fields)_

The following changes are made to `getUserProfile()` API:
- Optional ability to specify an array of profile fields as options to the function
- To retain backward compatibility:
    - function signature remains unchanged
    - default set of profile fields are requested when no fields are specified in options

The set of valid profile fields are provided to users of Botly as constants.
Unit tests are updated to validate this, and README is updated as well.

**VERSION BUMP is not done in this PR, but it is required.**